### PR TITLE
Add rggen-verilog and rggen-vhdl

### DIFF
--- a/images/base/scripts/dependencies.sh
+++ b/images/base/scripts/dependencies.sh
@@ -189,7 +189,9 @@ pip3 install --no-cache-dir \
 
 # Install Ruby packages via gem:
 gem install \
-	rggen
+	rggen \
+	rggen-verilog \
+	rggen-vhdl
 
 # Install node.js packages via npm:
 npm install -g \


### PR DESCRIPTION
First, thank you for adding my RgGen tool to your tool set list!

I think you use either Verilog or VHDL to write RTL code.
Therefore, RgGen should generate Verilog and VHDL code instead of SystemVerilog.

This PR is to add rggen-verilog and rggen-vhdl plugins to the dependencies.
